### PR TITLE
DAT-logging: Add structured logging across pipeline stages

### DIFF
--- a/src/adapters/telegram/webhook_handler.py
+++ b/src/adapters/telegram/webhook_handler.py
@@ -1,5 +1,6 @@
 """Telegram webhook handler orchestration adapter."""
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -7,6 +8,8 @@ from adapters.telegram.formatter import build_telegram_text_from_response
 from adapters.telegram.mapper import build_nlq_request_from_update
 from models.common import ErrorDetails, ErrorResponse, SuccessResponse
 from models.pipeline import NLQRequest, QuestionResponse
+
+_log = logging.getLogger("data_ontology")
 
 
 def handle_telegram_update(
@@ -19,6 +22,7 @@ def handle_telegram_update(
 ) -> SuccessResponse[dict[str, Any]] | ErrorResponse:
     mapped = build_nlq_request_from_update(update, request_id_provider=request_id_provider)
     if isinstance(mapped, ErrorResponse):
+        _log.error("[%s] Mapper failed [%s]: %s", mapped.request_id, mapped.error.code, mapped.error.message)
         return mapped
 
     chat_id, nlq_request = mapped
@@ -28,6 +32,7 @@ def handle_telegram_update(
     try:
         send_message(chat_id, telegram_text)
     except Exception as exc:
+        _log.error("[%s] send_message failed for chat_id=%s: %s", nlq_request.request_id, chat_id, exc)
         return ErrorResponse(
             request_id=nlq_request.request_id,
             error=ErrorDetails(

--- a/src/compiler/sql_compiler.py
+++ b/src/compiler/sql_compiler.py
@@ -1,5 +1,6 @@
 """Compile a validated QueryPlan into SQL and bound parameters."""
 
+import logging
 from typing import Any, Dict, Union
 
 from models.common import ErrorDetails, ErrorResponse, SuccessResponse
@@ -19,6 +20,9 @@ class SQLCompiler:
     passed in a bound_params dictionary using SQLite parameterized query format
     (e.g., :param_name) to prevent SQL injection.
     """
+
+    def __init__(self) -> None:
+        self._log = logging.getLogger("data_ontology")
 
     def compile(
         self, plan: QueryPlan, semantic_model: Dict[str, Any]
@@ -155,7 +159,10 @@ class SQLCompiler:
             sql=sql_template,
             bound_params=bound_params
         )
-        
+
+        self._log.info("[%s] SQL compiled for intent=%s", plan.request_id, plan.intent)
+        self._log.debug("[%s] SQL: %s | params: %s", plan.request_id, sql_template, bound_params)
+
         return SuccessResponse[CompiledSQL](
             request_id=plan.request_id,
             status="SUCCESS",

--- a/src/endpoints/routes/telegram/telegram_routes.py
+++ b/src/endpoints/routes/telegram/telegram_routes.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from uuid import uuid4
 
@@ -7,6 +8,8 @@ from fastapi.responses import JSONResponse
 from adapters.telegram.client import TelegramClient
 from adapters.telegram.webhook_handler import handle_telegram_update
 from models.common import ErrorResponse
+
+_log = logging.getLogger("data_ontology")
 
 telegram_router = APIRouter(prefix="/telegram", tags=["telegram"])
 
@@ -46,6 +49,7 @@ async def telegram_webhook(
     )
 
     if isinstance(result, ErrorResponse):
+        _log.error("[%s] Telegram webhook returning 400 [%s]: %s", result.request_id, result.error.code, result.error.message)
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content=result.model_dump(),

--- a/src/execution/sql_executor.py
+++ b/src/execution/sql_executor.py
@@ -1,5 +1,6 @@
 """Execute compiled SQL against the configured database."""
 
+import logging
 from typing import Union
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -32,6 +33,7 @@ class SQLExecutor:
             fact_flight_info_dao: The Fact Flight Info DAO
         """
         self._dao = fact_flight_info_dao
+        self._log = logging.getLogger("data_ontology")
 
     def execute(
         self, compiled_sql: CompiledSQL
@@ -76,14 +78,18 @@ class SQLExecutor:
                 request_id=compiled_sql.request_id,
                 result_set=[Row(data=res) for res in result_rows]
             )
-            
+
+            self._log.info("[%s] Query returned %d row(s)", compiled_sql.request_id, len(result_set.result_set))
+            self._log.debug("[%s] Result set: %s", compiled_sql.request_id, [row.data for row in result_set.result_set])
+
             return SuccessResponse[ResultSet](
                 request_id=compiled_sql.request_id,
                 status="SUCCESS",
                 data=result_set
             )
-        
+
         except SQLAlchemyError as e:
+            self._log.error("[%s] SQL execution error: %s", compiled_sql.request_id, str(e))
             return ErrorResponse(
                 request_id=compiled_sql.request_id,
                 error=ErrorDetails(

--- a/src/llm_gateway/providers/gemini_gateway.py
+++ b/src/llm_gateway/providers/gemini_gateway.py
@@ -11,8 +11,10 @@ Notes:
 
 import asyncio
 import json
+import logging
 import os
 import threading
+import time
 import traceback
 from concurrent.futures import TimeoutError as FutureTimeoutError
 
@@ -47,6 +49,7 @@ class GeminiGateway(LLMGateway):
         timeout_seconds: int = 30,
     ) -> None:
         self._bg_loop = _make_background_loop()
+        self._log = logging.getLogger("data_ontology")
         """Initialize Gemini gateway configuration.
 
         Args:
@@ -110,18 +113,24 @@ class GeminiGateway(LLMGateway):
             if ":" not in model_name:
                 model_name = f"google-gla:{model_name}"
 
+            self._log.info("[%s] Submitting prompt to Gemini model=%s", bundle.request_id, model_name)
             agent = _PydanticAIAgent(model_name, system_prompt=bundle.system_message)
 
+            _start = time.monotonic()
             future = asyncio.run_coroutine_threadsafe(
                 agent.run(bundle.user_message), self._bg_loop
             )
             result = future.result(timeout=self._timeout_seconds)
+            elapsed = time.monotonic() - _start
 
             raw_text = getattr(result, "output", result)
             if isinstance(raw_text, str):
                 text_output = raw_text
             else:
                 text_output = json.dumps(raw_text, ensure_ascii=False)
+
+            self._log.info("[%s] Gemini responded in %.2fs", bundle.request_id, elapsed)
+            self._log.debug("[%s] LLM raw response: %s", bundle.request_id, text_output.strip())
 
             return SuccessResponse[LLMRawResponse](
                 request_id=bundle.request_id,
@@ -132,6 +141,7 @@ class GeminiGateway(LLMGateway):
             )
 
         except FutureTimeoutError:
+            self._log.error("[%s] Gemini request timed out after %ds", bundle.request_id, self._timeout_seconds)
             return ErrorResponse(
                 request_id=bundle.request_id,
                 error=ErrorDetails(
@@ -151,6 +161,7 @@ class GeminiGateway(LLMGateway):
             else:
                 code = "llm_gateway_failed"
 
+            self._log.error("[%s] Gemini gateway error [%s]: %s", bundle.request_id, code, message)
             return ErrorResponse(
                 request_id=bundle.request_id,
                 error=ErrorDetails(

--- a/src/llm_gateway/providers/openai_gateway.py
+++ b/src/llm_gateway/providers/openai_gateway.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import os
+import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 
@@ -23,6 +25,7 @@ class OpenAIGateway(LLMGateway):
         self._api_key = api_key
         self._model = model or os.getenv("OPENAI_MODEL", "gpt-5.4-nano")
         self._timeout_seconds = timeout_seconds
+        self._log = logging.getLogger("data_ontology")
 
     def submit_prompt(
         self, bundle: PromptBundle
@@ -55,16 +58,22 @@ class OpenAIGateway(LLMGateway):
             if ":" not in model_name:
                 model_name = f"openai:{model_name}"
 
+            self._log.info("[%s] Submitting prompt to OpenAI model=%s", bundle.request_id, model_name)
             agent = _PydanticAIAgent(model_name, system_prompt=bundle.system_message)
+            _start = time.monotonic()
             with ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(agent.run_sync, bundle.user_message)
                 result = future.result(timeout=self._timeout_seconds)
+            elapsed = time.monotonic() - _start
 
             raw_text = getattr(result, "output", result)
             if isinstance(raw_text, str):
                 text_output = raw_text
             else:
                 text_output = json.dumps(raw_text, ensure_ascii=False)
+
+            self._log.info("[%s] OpenAI responded in %.2fs", bundle.request_id, elapsed)
+            self._log.debug("[%s] LLM raw response: %s", bundle.request_id, text_output.strip())
 
             return SuccessResponse[LLMRawResponse](
                 request_id=bundle.request_id,
@@ -75,6 +84,7 @@ class OpenAIGateway(LLMGateway):
             )
 
         except FutureTimeoutError:
+            self._log.error("[%s] OpenAI request timed out after %ds", bundle.request_id, self._timeout_seconds)
             return ErrorResponse(
                 request_id=bundle.request_id,
                 error=ErrorDetails(
@@ -94,6 +104,7 @@ class OpenAIGateway(LLMGateway):
             else:
                 code = "llm_gateway_failed"
 
+            self._log.error("[%s] OpenAI gateway error [%s]: %s", bundle.request_id, code, message)
             return ErrorResponse(
                 request_id=bundle.request_id,
                 error=ErrorDetails(

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -1,5 +1,7 @@
 """Pipeline orchestrator for NLQ execution."""
 
+import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -40,6 +42,7 @@ class Orchestrator:
         self._response_builder = response_builder
         self._error_response_builder = error_response_builder
         self._now_provider = now_provider
+        self._log = logging.getLogger("data_ontology")
 
     def handle_question(
         self, request: NLQRequest
@@ -50,6 +53,7 @@ class Orchestrator:
                 candidate = request.get("request_id")
                 if isinstance(candidate, str) and candidate:
                     request_id = candidate
+            self._log.error("[%s] Invalid request type: %s", request_id, type(request).__name__)
             return self._error_response_builder(
                 ErrorResponse(
                 request_id=request_id,
@@ -61,8 +65,12 @@ class Orchestrator:
                 )
             )
 
+        self._log.info("[%s] Received question: %s", request.request_id, request.question)
+        _start = time.monotonic()
+
         semantic_model_response = self._semantic_model_provider()
         if isinstance(semantic_model_response, ErrorResponse):
+            self._log.error("[%s] Stage semantic_model_provider failed: %s", request.request_id, semantic_model_response.error.message)
             return self._error_response_builder(semantic_model_response)
         semantic_model = semantic_model_response.data
 
@@ -75,6 +83,7 @@ class Orchestrator:
         )
         prompt_bundle_response = self._prompt_builder(prompt_request)
         if isinstance(prompt_bundle_response, ErrorResponse):
+            self._log.error("[%s] Stage prompt_builder failed: %s", request.request_id, prompt_bundle_response.error.message)
             return self._error_response_builder(prompt_bundle_response)
         prompt_bundle = prompt_bundle_response.data
         if not isinstance(prompt_bundle, PromptBundle):
@@ -90,6 +99,7 @@ class Orchestrator:
 
         raw_response_response = self._llm_gateway(prompt_bundle)
         if isinstance(raw_response_response, ErrorResponse):
+            self._log.error("[%s] Stage llm_gateway failed: %s", request.request_id, raw_response_response.error.message)
             return self._error_response_builder(raw_response_response)
         raw_response = raw_response_response.data
         if not isinstance(raw_response, LLMRawResponse):
@@ -105,6 +115,7 @@ class Orchestrator:
 
         query_plan_response = self._syntactic_validator(raw_response)
         if isinstance(query_plan_response, ErrorResponse):
+            self._log.error("[%s] Stage syntactic_validator failed: %s", request.request_id, query_plan_response.error.message)
             return self._error_response_builder(query_plan_response)
         query_plan = query_plan_response.data
         if not isinstance(query_plan, QueryPlan):
@@ -120,6 +131,7 @@ class Orchestrator:
 
         validated_query_plan_response = self._semantic_validator(query_plan, semantic_model)
         if isinstance(validated_query_plan_response, ErrorResponse):
+            self._log.error("[%s] Stage semantic_validator failed: %s", request.request_id, validated_query_plan_response.error.message)
             return self._error_response_builder(validated_query_plan_response)
         validated_query_plan = validated_query_plan_response.data
         if not isinstance(validated_query_plan, QueryPlan):
@@ -135,6 +147,7 @@ class Orchestrator:
 
         compiled_sql_response = self._sql_compiler(validated_query_plan, semantic_model)
         if isinstance(compiled_sql_response, ErrorResponse):
+            self._log.error("[%s] Stage sql_compiler failed: %s", request.request_id, compiled_sql_response.error.message)
             return self._error_response_builder(compiled_sql_response)
         compiled_sql = compiled_sql_response.data
         if not isinstance(compiled_sql, CompiledSQL):
@@ -150,6 +163,7 @@ class Orchestrator:
 
         result_set_response = self._sql_executor(compiled_sql)
         if isinstance(result_set_response, ErrorResponse):
+            self._log.error("[%s] Stage sql_executor failed: %s", request.request_id, result_set_response.error.message)
             return self._error_response_builder(result_set_response)
         result_set = result_set_response.data
         if not isinstance(result_set, ResultSet):
@@ -165,5 +179,9 @@ class Orchestrator:
 
         response = self._response_builder(result_set)
         if isinstance(response, ErrorResponse):
+            self._log.error("[%s] Stage response_builder failed: %s", request.request_id, response.error.message)
             return self._error_response_builder(response)
+
+        elapsed = time.monotonic() - _start
+        self._log.info("[%s] Pipeline completed in %.2fs", request.request_id, elapsed)
         return response

--- a/src/prompt_builder/prompt_builder.py
+++ b/src/prompt_builder/prompt_builder.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -10,6 +11,7 @@ class PromptBuilder:
     def __init__(self, template_path: str | None = None) -> None:
         default_path = Path(__file__).with_name("templates").joinpath("query_plan_prompt.j2")
         self._template_path = Path(template_path) if template_path else default_path
+        self._log = logging.getLogger("data_ontology")
 
     def _load_default_template(self) -> str:
         return self._template_path.read_text(encoding="utf-8")
@@ -57,6 +59,9 @@ class PromptBuilder:
                 system_message="You are an AI query planner. Return strictly valid JSON only.",
                 user_message=user_message,
             )
+            self._log.info("[%s] Prompt built", request.request_id)
+            self._log.debug("[%s] system_message: %s", request.request_id, bundle.system_message)
+            self._log.debug("[%s] user_message: %s", request.request_id, bundle.user_message)
             return SuccessResponse[PromptBundle](
                 request_id=request.request_id,
                 data=bundle,

--- a/src/validators/semantic/semantic_validator.py
+++ b/src/validators/semantic/semantic_validator.py
@@ -1,5 +1,6 @@
 """Semantic validator against semantic model intents and required params."""
 
+import logging
 import re
 from typing import Any, Dict
 
@@ -23,6 +24,9 @@ class SemanticValidator:
     """
 
     COMPONENT_NAME = "semantic_validator"
+
+    def __init__(self) -> None:
+        self._log = logging.getLogger("data_ontology")
 
     def validate(
         self,
@@ -129,6 +133,7 @@ class SemanticValidator:
         # -----------------------------------------------
         # Success
         # -----------------------------------------------
+        self._log.info("[%s] Semantic validation passed for intent=%s params=%s", plan.request_id, plan.intent, list(plan.parameters.keys()))
         return SuccessResponse(
             request_id=plan.request_id,
             data=plan,
@@ -141,6 +146,7 @@ class SemanticValidator:
         message: str,
         details: Dict[str, Any] | None = None,
     ) -> ErrorResponse:
+        self._log.error("[%s] Semantic validation failed [%s]: %s", request_id, code, message)
         return ErrorResponse(
             request_id=request_id,
             error=ErrorDetails(

--- a/src/validators/syntactic/syntactic_validator.py
+++ b/src/validators/syntactic/syntactic_validator.py
@@ -1,6 +1,7 @@
 """Syntactic validator for raw LLM output."""
 
 import json
+import logging
 
 from pydantic import ValidationError
 
@@ -25,6 +26,9 @@ class SyntacticValidator:
         ErrorResponse on failure
     """
 
+    def __init__(self) -> None:
+        self._log = logging.getLogger("data_ontology")
+
     def validate(
         self, raw_response: LLMRawResponse
     ) -> SuccessResponse[QueryPlan] | ErrorResponse:
@@ -38,6 +42,8 @@ class SyntacticValidator:
         try:
             parsed = json.loads(cleaned_text)
         except json.JSONDecodeError as e:
+            self._log.error("[%s] Syntactic validation failed - malformed JSON: %s", request_id, str(e))
+            self._log.debug("[%s] Raw LLM text that failed parsing: %s", request_id, cleaned_text)
             return ErrorResponse(
                 request_id=request_id,
                 error=ErrorDetails(
@@ -55,6 +61,7 @@ class SyntacticValidator:
         try:
             query_plan = QueryPlan(**parsed)
         except ValidationError as e:
+            self._log.error("[%s] Syntactic validation failed - schema error: %s", request_id, e.errors())
             return ErrorResponse(
                 request_id=request_id,
                 error=ErrorDetails(
@@ -67,6 +74,7 @@ class SyntacticValidator:
 
         # Step 5: Confidence range guard
         if not (0.0 <= query_plan.confidence <= 1.0):
+            self._log.error("[%s] Syntactic validation failed - confidence out of range: %s", request_id, query_plan.confidence)
             return ErrorResponse(
                 request_id=request_id,
                 error=ErrorDetails(
@@ -77,6 +85,8 @@ class SyntacticValidator:
                 ),
             )
 
+        self._log.info("[%s] Parsed intent=%s confidence=%.2f", request_id, query_plan.intent, query_plan.confidence)
+        self._log.debug("[%s] QueryPlan: %s", request_id, query_plan.model_dump())
         return SuccessResponse(
             request_id=request_id,
             data=query_plan,

--- a/tests/unit/adapters/telegram/test_telegram_webhook_handler.py
+++ b/tests/unit/adapters/telegram/test_telegram_webhook_handler.py
@@ -77,7 +77,7 @@ def test_handle_telegram_update_orchestrator_error_still_sends_message():
     assert "Malformed LLM output" in sent_text
 
 
-def test_handle_telegram_update_invalid_update_returns_error_and_skips_calls():
+def test_handle_telegram_update_invalid_update_returns_error_and_skips_calls(caplog):
     update = {
         "update_id": 9103,
         "message": {
@@ -89,21 +89,23 @@ def test_handle_telegram_update_invalid_update_returns_error_and_skips_calls():
     orchestrator = Mock()
     send_message = Mock()
 
-    result = handle_telegram_update(
-        update=update,
-        orchestrator_handle_question=orchestrator,
-        send_message=send_message,
-        request_id_provider=lambda: "req-tg-h3",
-    )
+    with caplog.at_level("ERROR", logger="data_ontology"):
+        result = handle_telegram_update(
+            update=update,
+            orchestrator_handle_question=orchestrator,
+            send_message=send_message,
+            request_id_provider=lambda: "req-tg-h3",
+        )
 
     assert isinstance(result, ErrorResponse)
     assert result.request_id == "req-tg-h3"
     assert result.error.component == "telegram_mapper"
     orchestrator.assert_not_called()
     send_message.assert_not_called()
+    assert any("Mapper failed" in r.message for r in caplog.records)
 
 
-def test_handle_telegram_update_send_failure_returns_delivery_error_response():
+def test_handle_telegram_update_send_failure_returns_delivery_error_response(caplog):
     update = {
         "update_id": 9104,
         "message": {
@@ -123,14 +125,16 @@ def test_handle_telegram_update_send_failure_returns_delivery_error_response():
     )
     send_message = Mock(side_effect=RuntimeError("Telegram unavailable"))
 
-    result = handle_telegram_update(
-        update=update,
-        orchestrator_handle_question=orchestrator,
-        send_message=send_message,
-        request_id_provider=lambda: "req-tg-h4",
-    )
+    with caplog.at_level("ERROR", logger="data_ontology"):
+        result = handle_telegram_update(
+            update=update,
+            orchestrator_handle_question=orchestrator,
+            send_message=send_message,
+            request_id_provider=lambda: "req-tg-h4",
+        )
 
     assert isinstance(result, ErrorResponse)
     assert result.request_id == "req-tg-h4"
     assert result.error.component == "telegram_webhook"
     assert result.error.code == "telegram_delivery_failed"
+    assert any("send_message failed" in r.message and "Telegram unavailable" in r.message for r in caplog.records)

--- a/tests/unit/endpoints/test_telegram_routes.py
+++ b/tests/unit/endpoints/test_telegram_routes.py
@@ -112,16 +112,18 @@ def test_webhook_valid_secret_passes(client, orchestrator, valid_update, success
     assert response.status_code == 200
 
 
-def test_webhook_invalid_update_returns_400(client, orchestrator, monkeypatch):
+def test_webhook_invalid_update_returns_400(client, orchestrator, monkeypatch, caplog):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
     monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_message", Mock())
 
     invalid_update = {"update_id": 1, "message": {"chat": {"id": 12345}}}  # missing text
 
-    response = client.post("/telegram/webhook", json=invalid_update)
+    with caplog.at_level("ERROR", logger="data_ontology"):
+        response = client.post("/telegram/webhook", json=invalid_update)
 
     assert response.status_code == 400
     orchestrator.handle_question.assert_not_called()
+    assert any("returning 400" in r.message for r in caplog.records)
 
 
 def test_webhook_orchestrator_error_still_delivers_message_and_returns_200(


### PR DESCRIPTION
Adds INFO/ERROR/DEBUG logging to all 7 pipeline stages and the Telegram webhook handler using the existing data_ontology logger. Every log line is prefixed with [request_id] for end-to-end traceability.

Pipeline stages:
- Orchestrator: request received, per-stage error, total latency
- Prompt Builder: prompt built (DEBUG: full prompt content)
- Gemini/OpenAI Gateway: model, latency, errors (DEBUG: raw LLM response)
- Syntactic Validator: parsed intent + confidence, errors (DEBUG: QueryPlan)
- Semantic Validator: validation passed/failed with intent + params
- SQL Compiler: compiled intent (DEBUG: full SQL + bound params)
- SQL Executor: row count returned, errors (DEBUG: full result set)

Telegram webhook handler:
- Log mapper failures with error code and message
- Log send_message exceptions with chat_id and exception detail
- Log before returning 400 with error code and message

Tests updated to assert log calls on failure paths.