### PR TITLE
DAT-114: Add Telegram typing indicator and fix dev scripts

### DIFF
--- a/scripts/start_local_dev.sh
+++ b/scripts/start_local_dev.sh
@@ -11,6 +11,7 @@ ENV_FILE="$SCRIPT_DIR/local.env"
 [[ -f "$ENV_FILE" ]] || { echo "ERROR: $ENV_FILE not found. Copy scripts/local.env.example to scripts/local.env and fill in your credentials."; exit 1; }
 # shellcheck source=/dev/null
 source "$ENV_FILE"
+export GEMINI_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_WEBHOOK_SECRET POSTGRES_USER POSTGRES_PASSWORD
 
 log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 err()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2; exit 1; }

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -12,6 +12,7 @@ ENV_FILE="$SCRIPT_DIR/local.env"
 [[ -f "$ENV_FILE" ]] || { echo "ERROR: $ENV_FILE not found. Copy scripts/local.env.example to scripts/local.env and fill in your credentials."; exit 1; }
 # shellcheck source=/dev/null
 source "$ENV_FILE"
+export GEMINI_API_KEY POSTGRES_USER POSTGRES_PASSWORD
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 err() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2; exit 1; }

--- a/src/adapters/telegram/client.py
+++ b/src/adapters/telegram/client.py
@@ -20,19 +20,17 @@ class TelegramClient:
         self._retry_delay_seconds = 0.2
 
     def send_typing_action(self, chat_id: int) -> None:
-        payload = json.dumps({"chat_id": chat_id, "action": "typing"}).encode("utf-8")
-        req = request.Request(
-            url=f"{self._base_url}/sendChatAction",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
         try:
-            with request.urlopen(req, timeout=10) as resp:
-                status = getattr(resp, "status", 200)
-                if status >= 400:
-                    raise RuntimeError(f"Telegram sendChatAction failed with status {status}")
-        except error.URLError as exc:
+            response = self._session.post(
+                url=f"{self._base_url}/sendChatAction",
+                json={"chat_id": chat_id, "action": "typing"},
+                timeout=self._timeout_seconds,
+            )
+            response.raise_for_status()
+        except HTTPError as exc:
+            status = getattr(exc.response, "status_code", "unknown")
+            raise RuntimeError(f"Telegram sendChatAction failed with status {status}") from exc
+        except RequestException as exc:
             raise RuntimeError(f"Telegram sendChatAction request failed: {exc}") from exc
 
     def send_message(self, chat_id: int, text: str) -> None:


### PR DESCRIPTION
## Summary
- Add `send_typing_action` to `TelegramClient` using `requests.Session` (consistent with `send_message`)
- Fix `start_local_dev.sh` and `test_e2e.sh` to export env vars to child processes so `TELEGRAM_BOT_TOKEN` and `GEMINI_API_KEY` are visible to the server

## Test plan
- [ ] `./scripts/start_local_dev.sh` — server starts, no 500s on webhook
- [ ] Message the bot — typing indicator appears before response
- [ ] `./scripts/test_e2e.sh` — all 6 golden questions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)