### PR TITLE
DAT-115: Refactor Telegram adapter to follow SOLID principles

### DIFF
--- a/scripts/start_local_dev.sh
+++ b/scripts/start_local_dev.sh
@@ -11,6 +11,7 @@ ENV_FILE="$SCRIPT_DIR/local.env"
 [[ -f "$ENV_FILE" ]] || { echo "ERROR: $ENV_FILE not found. Copy scripts/local.env.example to scripts/local.env and fill in your credentials."; exit 1; }
 # shellcheck source=/dev/null
 source "$ENV_FILE"
+export GEMINI_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_WEBHOOK_SECRET POSTGRES_USER POSTGRES_PASSWORD
 
 log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 err()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2; exit 1; }

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -12,6 +12,7 @@ ENV_FILE="$SCRIPT_DIR/local.env"
 [[ -f "$ENV_FILE" ]] || { echo "ERROR: $ENV_FILE not found. Copy scripts/local.env.example to scripts/local.env and fill in your credentials."; exit 1; }
 # shellcheck source=/dev/null
 source "$ENV_FILE"
+export GEMINI_API_KEY POSTGRES_USER POSTGRES_PASSWORD
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 err() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2; exit 1; }

--- a/src/adapters/telegram/__init__.py
+++ b/src/adapters/telegram/__init__.py
@@ -1,11 +1,13 @@
 from adapters.telegram.client import TelegramClient
-from adapters.telegram.formatter import build_telegram_text_from_response
-from adapters.telegram.mapper import build_nlq_request_from_update
-from adapters.telegram.webhook_handler import handle_telegram_update
+from adapters.telegram.formatter import TelegramFormatter, build_telegram_text_from_response
+from adapters.telegram.mapper import TelegramUpdateMapper, build_nlq_request_from_update
+from adapters.telegram.webhook_handler import TelegramWebhookHandler
 
 __all__ = [
     "TelegramClient",
+    "TelegramFormatter",
+    "TelegramUpdateMapper",
+    "TelegramWebhookHandler",
     "build_nlq_request_from_update",
     "build_telegram_text_from_response",
-    "handle_telegram_update",
 ]

--- a/src/adapters/telegram/client.py
+++ b/src/adapters/telegram/client.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import json
 import time
 
 import requests
 from requests import RequestException
 from requests.exceptions import HTTPError
 
+from adapters.telegram.interfaces import MessageClient
 
-class TelegramClient:
+
+class TelegramClient(MessageClient):
     def __init__(self, bot_token: str) -> None:
         self._bot_token = bot_token
         self._base_url = f"https://api.telegram.org/bot{bot_token}"
@@ -19,7 +20,7 @@ class TelegramClient:
         self._max_attempts = 2
         self._retry_delay_seconds = 0.2
 
-    def send_typing_action(self, chat_id: int) -> None:
+    def send_typing(self, chat_id: int) -> None:
         try:
             response = self._session.post(
                 url=f"{self._base_url}/sendChatAction",

--- a/src/adapters/telegram/client.py
+++ b/src/adapters/telegram/client.py
@@ -20,19 +20,17 @@ class TelegramClient:
         self._retry_delay_seconds = 0.2
 
     def send_typing_action(self, chat_id: int) -> None:
-        payload = json.dumps({"chat_id": chat_id, "action": "typing"}).encode("utf-8")
-        req = request.Request(
-            url=f"{self._base_url}/sendChatAction",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
         try:
-            with request.urlopen(req, timeout=10) as resp:
-                status = getattr(resp, "status", 200)
-                if status >= 400:
-                    raise RuntimeError(f"Telegram sendChatAction failed with status {status}")
-        except error.URLError as exc:
+            response = self._session.post(
+                url=f"{self._base_url}/sendChatAction",
+                json={"chat_id": chat_id, "action": "typing"},
+                timeout=self._timeout_seconds,
+            )
+            response.raise_for_status()
+        except HTTPError as exc:
+            status = getattr(exc.response, "status_code", "unknown")
+            raise RuntimeError(f"Telegram sendChatAction failed with status {status}") from exc
+        except RequestException as exc:
             raise RuntimeError(f"Telegram sendChatAction request failed: {exc}") from exc
 
     def send_message(self, chat_id: int, text: str) -> None:

--- a/src/adapters/telegram/formatter.py
+++ b/src/adapters/telegram/formatter.py
@@ -1,5 +1,6 @@
 """Format orchestration responses into Telegram message text."""
 
+from adapters.telegram.interfaces import ResponseFormatter
 from models.common import ErrorResponse, SuccessResponse
 from models.pipeline import QuestionResponse
 
@@ -14,3 +15,8 @@ def build_telegram_text_from_response(
         return f"{response.error.message} (request_id: {response.request_id})"
 
     return "Unable to process response. Please try again."
+
+
+class TelegramFormatter(ResponseFormatter):
+    def format(self, response: SuccessResponse[QuestionResponse] | ErrorResponse) -> str:
+        return build_telegram_text_from_response(response)

--- a/src/adapters/telegram/interfaces.py
+++ b/src/adapters/telegram/interfaces.py
@@ -1,0 +1,29 @@
+"""Abstract interfaces for the Telegram adapter layer."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from models.common import ErrorResponse, SuccessResponse
+from models.pipeline import NLQRequest, QuestionResponse
+
+
+class UpdateMapper(ABC):
+    @abstractmethod
+    def map(self, update: dict[str, Any]) -> tuple[int, NLQRequest] | ErrorResponse:
+        pass
+
+
+class MessageClient(ABC):
+    @abstractmethod
+    def send_message(self, chat_id: int, text: str) -> None:
+        pass
+
+    @abstractmethod
+    def send_typing(self, chat_id: int) -> None:
+        pass
+
+
+class ResponseFormatter(ABC):
+    @abstractmethod
+    def format(self, response: SuccessResponse[QuestionResponse] | ErrorResponse) -> str:
+        pass

--- a/src/adapters/telegram/mapper.py
+++ b/src/adapters/telegram/mapper.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from adapters.telegram.interfaces import UpdateMapper
 from models.common import ErrorDetails, ErrorResponse
 from models.pipeline import NLQRequest
 
@@ -51,3 +52,11 @@ def build_nlq_request_from_update(
         request_id=request_id,
         question=text.strip(),
     )
+
+
+class TelegramUpdateMapper(UpdateMapper):
+    def __init__(self, request_id_provider: Callable[[], str]) -> None:
+        self._request_id_provider = request_id_provider
+
+    def map(self, update: dict[str, Any]) -> tuple[int, NLQRequest] | ErrorResponse:
+        return build_nlq_request_from_update(update, request_id_provider=self._request_id_provider)

--- a/src/adapters/telegram/webhook_handler.py
+++ b/src/adapters/telegram/webhook_handler.py
@@ -4,55 +4,85 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from adapters.telegram.formatter import build_telegram_text_from_response
-from adapters.telegram.mapper import build_nlq_request_from_update
+from adapters.telegram.interfaces import MessageClient, ResponseFormatter, UpdateMapper
 from models.common import ErrorDetails, ErrorResponse, SuccessResponse
 from models.pipeline import NLQRequest, QuestionResponse
 
 _log = logging.getLogger("data_ontology")
 
 
-def handle_telegram_update(
-    update: dict[str, Any],
-    orchestrator_handle_question: Callable[
-        [NLQRequest], SuccessResponse[QuestionResponse] | ErrorResponse
-    ],
-    send_message: Callable[[int, str], None],
-    send_typing_action: Callable[[int], None],
-    request_id_provider: Callable[[], str],
-) -> SuccessResponse[dict[str, Any]] | ErrorResponse:
-    mapped = build_nlq_request_from_update(update, request_id_provider=request_id_provider)
-    if isinstance(mapped, ErrorResponse):
-        _log.error("[%s] Mapper failed [%s]: %s", mapped.request_id, mapped.error.code, mapped.error.message)
-        return mapped
+class TelegramWebhookHandler:
+    def __init__(
+        self,
+        mapper: UpdateMapper,
+        orchestrator_handle_question: Callable[
+            [NLQRequest], SuccessResponse[QuestionResponse] | ErrorResponse
+        ],
+        client: MessageClient,
+        formatter: ResponseFormatter,
+    ) -> None:
+        self._mapper = mapper
+        self._orchestrator_handle_question = orchestrator_handle_question
+        self._client = client
+        self._formatter = formatter
 
-    chat_id, nlq_request = mapped
+    def handle(self, update: dict[str, Any]) -> SuccessResponse[dict[str, Any]] | ErrorResponse:
+        mapped = self._mapper.map(update)
 
-    try:
-        send_typing_action(chat_id)
-    except Exception as exc:
-        _log.warning("[%s] send_typing_action failed for chat_id=%s: %s", nlq_request.request_id, chat_id, exc)
+        if isinstance(mapped, ErrorResponse):
+            _log.error(
+                "[%s] Mapper failed [%s]: %s",
+                mapped.request_id,
+                mapped.error.code,
+                mapped.error.message,
+            )
+            return mapped
 
-    orchestration_response = orchestrator_handle_question(nlq_request)
-    telegram_text = build_telegram_text_from_response(orchestration_response)
+        chat_id, nlq_request = mapped
 
-    try:
-        send_message(chat_id, telegram_text)
-    except Exception as exc:
-        _log.error("[%s] send_message failed for chat_id=%s: %s", nlq_request.request_id, chat_id, exc)
-        return ErrorResponse(
-            request_id=nlq_request.request_id,
-            error=ErrorDetails(
-                code="telegram_delivery_failed",
-                message=f"Failed to deliver Telegram message: {exc}",
-                component="telegram_webhook",
-            ),
+        self._safe_send_typing(chat_id, nlq_request.request_id)
+
+        orchestration_response = self._orchestrator_handle_question(nlq_request)
+        telegram_text = self._formatter.format(orchestration_response)
+
+        return self._deliver_message(chat_id, nlq_request.request_id, telegram_text)
+
+    def _safe_send_typing(self, chat_id: int, request_id: str) -> None:
+        try:
+            self._client.send_typing(chat_id)
+        except Exception as exc:
+            _log.warning(
+                "[%s] send_typing failed for chat_id=%s: %s",
+                request_id,
+                chat_id,
+                exc,
+            )
+
+    def _deliver_message(
+        self,
+        chat_id: int,
+        request_id: str,
+        text: str,
+    ) -> SuccessResponse[dict[str, Any]] | ErrorResponse:
+        try:
+            self._client.send_message(chat_id, text)
+        except Exception as exc:
+            _log.error(
+                "[%s] send_message failed for chat_id=%s: %s",
+                request_id,
+                chat_id,
+                exc,
+            )
+            return ErrorResponse(
+                request_id=request_id,
+                error=ErrorDetails(
+                    code="telegram_delivery_failed",
+                    message=f"Failed to deliver Telegram message: {exc}",
+                    component="telegram_webhook",
+                ),
+            )
+
+        return SuccessResponse(
+            request_id=request_id,
+            data={"chat_id": chat_id, "delivered": True},
         )
-
-    return SuccessResponse(
-        request_id=nlq_request.request_id,
-        data={
-            "chat_id": chat_id,
-            "delivered": True,
-        },
-    )

--- a/src/endpoints/routes/telegram/telegram_routes.py
+++ b/src/endpoints/routes/telegram/telegram_routes.py
@@ -6,7 +6,9 @@ from fastapi import APIRouter, Header, Request, status
 from fastapi.responses import JSONResponse
 
 from adapters.telegram.client import TelegramClient
-from adapters.telegram.webhook_handler import handle_telegram_update
+from adapters.telegram.formatter import TelegramFormatter
+from adapters.telegram.mapper import TelegramUpdateMapper
+from adapters.telegram.webhook_handler import TelegramWebhookHandler
 from models.common import ErrorResponse
 
 _log = logging.getLogger("data_ontology")
@@ -40,14 +42,16 @@ async def telegram_webhook(
         )
 
     payload = await request.json()
-    telegram_client = TelegramClient(bot_token=bot_token)
-    result = handle_telegram_update(
-        update=payload,
+    request_id_provider = lambda: str(uuid4())
+
+    handler = TelegramWebhookHandler(
+        mapper=TelegramUpdateMapper(request_id_provider),
         orchestrator_handle_question=request.app.state.orchestrator.handle_question,
-        send_message=telegram_client.send_message,
-        send_typing_action=telegram_client.send_typing_action,
-        request_id_provider=lambda: str(uuid4()),
+        client=TelegramClient(bot_token=bot_token),
+        formatter=TelegramFormatter(),
     )
+
+    result = handler.handle(payload)
 
     if isinstance(result, ErrorResponse):
         _log.error("[%s] Telegram webhook returning 400 [%s]: %s", result.request_id, result.error.code, result.error.message)

--- a/tests/integration/api/test_telegram_webhook_integration.py
+++ b/tests/integration/api/test_telegram_webhook_integration.py
@@ -60,6 +60,7 @@ def test_telegram_webhook_returns_200_and_delivery_status(monkeypatch):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
     monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
     monkeypatch.setattr(TelegramClient, "send_message", lambda self, chat_id, text: None)
+    monkeypatch.setattr(TelegramClient, "send_typing", lambda self, chat_id: None)
     request = _FakeRequest({"message": {"chat": {"id": 123}, "text": "hello"}})
 
     response = asyncio.run(telegram_webhook(request=request))

--- a/tests/unit/adapters/telegram/test_telegram_webhook_handler.py
+++ b/tests/unit/adapters/telegram/test_telegram_webhook_handler.py
@@ -1,144 +1,112 @@
 from unittest.mock import Mock
 
-from adapters.telegram.webhook_handler import handle_telegram_update
+from adapters.telegram.webhook_handler import TelegramWebhookHandler
 from models.common import ErrorDetails, ErrorResponse, SuccessResponse
 from models.pipeline import NLQRequest, QuestionResponse
 
 
-def test_handle_telegram_update_happy_path_calls_orchestrator_and_sender():
-    update = {
-        "update_id": 9101,
-        "message": {
-            "message_id": 21,
-            "chat": {"id": 777, "type": "private"},
-            "text": "Show my top holdings",
-        },
-    }
-    orchestrator = Mock(
-        return_value=SuccessResponse(
-            request_id="req-tg-h1",
-            data=QuestionResponse(
-                request_id="req-tg-h1",
-                response="I found 2 matching records.",
-            ),
-        )
-    )
-    send_message = Mock()
+def _make_handler(orchestrator=None, send_message=None, send_typing=None, mapper=None, formatter=None):
+    """Build a TelegramWebhookHandler with sensible defaults."""
+    default_chat_id = 777
+    default_request_id = "req-tg-1"
 
-    result = handle_telegram_update(
-        update=update,
+    if mapper is None:
+        mapper = Mock()
+        mapper.map.return_value = (default_chat_id, NLQRequest(request_id=default_request_id, question="test"))
+
+    if orchestrator is None:
+        orchestrator = Mock(
+            return_value=SuccessResponse(
+                request_id=default_request_id,
+                data=QuestionResponse(request_id=default_request_id, response="Here are your results."),
+            )
+        )
+
+    client = Mock()
+    client.send_message = send_message or Mock()
+    client.send_typing = send_typing or Mock()
+
+    if formatter is None:
+        formatter = Mock()
+        formatter.format.return_value = "Here are your results."
+
+    return TelegramWebhookHandler(
+        mapper=mapper,
         orchestrator_handle_question=orchestrator,
-        send_message=send_message,
-        send_typing_action=Mock(),
-        request_id_provider=lambda: "req-tg-h1",
-    )
+        client=client,
+        formatter=formatter,
+    ), client
+
+
+def test_handle_happy_path_calls_orchestrator_and_sender():
+    handler, client = _make_handler()
+    update = {"update_id": 1}
+
+    result = handler.handle(update)
 
     assert isinstance(result, SuccessResponse)
-    assert result.request_id == "req-tg-h1"
-    assert result.status == "SUCCESS"
-    orchestrator.assert_called_once()
-    nlq_request = orchestrator.call_args[0][0]
-    assert isinstance(nlq_request, NLQRequest)
-    assert nlq_request.question == "Show my top holdings"
-    send_message.assert_called_once_with(777, "I found 2 matching records.")
+    assert result.data["delivered"] is True
+    client.send_message.assert_called_once()
+    client.send_typing.assert_called_once()
 
 
-def test_handle_telegram_update_orchestrator_error_still_sends_message():
-    update = {
-        "update_id": 9102,
-        "message": {
-            "message_id": 22,
-            "chat": {"id": 888, "type": "private"},
-            "text": "Show my top holdings",
-        },
-    }
+def test_handle_orchestrator_error_still_sends_message():
     orchestrator = Mock(
         return_value=ErrorResponse(
-            request_id="req-tg-h2",
-            error=ErrorDetails(
-                code="invalid_syntax",
-                message="Malformed LLM output",
-                component="syntactic_validator",
-            ),
+            request_id="req-tg-2",
+            error=ErrorDetails(code="invalid_syntax", message="Malformed LLM output", component="syntactic_validator"),
         )
     )
-    send_message = Mock()
+    formatter = Mock()
+    formatter.format.return_value = "Malformed LLM output (request_id: req-tg-2)"
 
-    result = handle_telegram_update(
-        update=update,
-        orchestrator_handle_question=orchestrator,
-        send_message=send_message,
-        send_typing_action=Mock(),
-        request_id_provider=lambda: "req-tg-h2",
-    )
+    handler, client = _make_handler(orchestrator=orchestrator, formatter=formatter)
+    result = handler.handle({})
 
     assert isinstance(result, SuccessResponse)
-    assert result.request_id == "req-tg-h2"
-    send_message.assert_called_once()
-    sent_text = send_message.call_args[0][1]
+    client.send_message.assert_called_once()
+    sent_text = client.send_message.call_args[0][1]
     assert "Malformed LLM output" in sent_text
 
 
-def test_handle_telegram_update_invalid_update_returns_error_and_skips_calls(caplog):
-    update = {
-        "update_id": 9103,
-        "message": {
-            "message_id": 23,
-            "chat": {"id": 999, "type": "private"},
-            # missing text
-        },
-    }
-    orchestrator = Mock()
-    send_message = Mock()
+def test_handle_invalid_update_returns_error_and_skips_calls(caplog):
+    mapper = Mock()
+    mapper.map.return_value = ErrorResponse(
+        request_id="req-tg-3",
+        error=ErrorDetails(code="invalid_telegram_update", message="Missing text", component="telegram_mapper"),
+    )
+    handler, client = _make_handler(mapper=mapper)
 
     with caplog.at_level("ERROR", logger="data_ontology"):
-        result = handle_telegram_update(
-            update=update,
-            orchestrator_handle_question=orchestrator,
-            send_message=send_message,
-            send_typing_action=Mock(),
-            request_id_provider=lambda: "req-tg-h3",
-        )
+        result = handler.handle({})
 
     assert isinstance(result, ErrorResponse)
-    assert result.request_id == "req-tg-h3"
     assert result.error.component == "telegram_mapper"
-    orchestrator.assert_not_called()
-    send_message.assert_not_called()
+    client.send_message.assert_not_called()
+    client.send_typing.assert_not_called()
     assert any("Mapper failed" in r.message for r in caplog.records)
 
 
-def test_handle_telegram_update_send_failure_returns_delivery_error_response(caplog):
-    update = {
-        "update_id": 9104,
-        "message": {
-            "message_id": 24,
-            "chat": {"id": 123, "type": "private"},
-            "text": "Show my top holdings",
-        },
-    }
-    orchestrator = Mock(
-        return_value=SuccessResponse(
-            request_id="req-tg-h4",
-            data=QuestionResponse(
-                request_id="req-tg-h4",
-                response="I found 1 matching record.",
-            ),
-        )
-    )
+def test_handle_send_failure_returns_delivery_error(caplog):
     send_message = Mock(side_effect=RuntimeError("Telegram unavailable"))
+    handler, client = _make_handler(send_message=send_message)
 
     with caplog.at_level("ERROR", logger="data_ontology"):
-        result = handle_telegram_update(
-            update=update,
-            orchestrator_handle_question=orchestrator,
-            send_message=send_message,
-            send_typing_action=Mock(),
-            request_id_provider=lambda: "req-tg-h4",
-        )
+        result = handler.handle({})
 
     assert isinstance(result, ErrorResponse)
-    assert result.request_id == "req-tg-h4"
-    assert result.error.component == "telegram_webhook"
     assert result.error.code == "telegram_delivery_failed"
+    assert result.error.component == "telegram_webhook"
     assert any("send_message failed" in r.message and "Telegram unavailable" in r.message for r in caplog.records)
+
+
+def test_handle_typing_failure_does_not_block_response(caplog):
+    send_typing = Mock(side_effect=RuntimeError("typing failed"))
+    handler, client = _make_handler(send_typing=send_typing)
+
+    with caplog.at_level("WARNING", logger="data_ontology"):
+        result = handler.handle({})
+
+    assert isinstance(result, SuccessResponse)
+    client.send_message.assert_called_once()
+    assert any("send_typing failed" in r.message for r in caplog.records)

--- a/tests/unit/endpoints/test_telegram_routes.py
+++ b/tests/unit/endpoints/test_telegram_routes.py
@@ -65,6 +65,7 @@ def error_response():
 def test_webhook_happy_path_returns_200(client, orchestrator, valid_update, success_response, monkeypatch):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
     monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_message", Mock())
+    monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_typing", Mock())
     orchestrator.handle_question.return_value = success_response
 
     response = client.post("/telegram/webhook", json=valid_update)
@@ -101,6 +102,7 @@ def test_webhook_valid_secret_passes(client, orchestrator, valid_update, success
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
     monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "correct-secret")
     monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_message", Mock())
+    monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_typing", Mock())
     orchestrator.handle_question.return_value = success_response
 
     response = client.post(
@@ -115,6 +117,7 @@ def test_webhook_valid_secret_passes(client, orchestrator, valid_update, success
 def test_webhook_invalid_update_returns_400(client, orchestrator, monkeypatch, caplog):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
     monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_message", Mock())
+    monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_typing", Mock())
 
     invalid_update = {"update_id": 1, "message": {"chat": {"id": 12345}}}  # missing text
 
@@ -132,6 +135,7 @@ def test_webhook_orchestrator_error_still_delivers_message_and_returns_200(
     send_message = Mock()
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
     monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_message", send_message)
+    monkeypatch.setattr("adapters.telegram.client.TelegramClient.send_typing", Mock())
     orchestrator.handle_question.return_value = error_response
 
     response = client.post("/telegram/webhook", json=valid_update)


### PR DESCRIPTION
## Summary
- Add `interfaces.py` with `UpdateMapper`, `MessageClient`, `ResponseFormatter` ABCs
- Introduce `TelegramUpdateMapper` and `TelegramFormatter` concrete implementations
- `TelegramClient` now implements `MessageClient`; rename `send_typing_action` → `send_typing`
- Replace `handle_telegram_update` function with `TelegramWebhookHandler` class
- Update `telegram_routes.py` to wire `TelegramWebhookHandler`
- Rewrite and extend webhook handler tests (214 passing)

## Test plan
- [ ] `uv run pytest` — all 214 tests pass
- [ ] `./scripts/start_local_dev.sh` — bot responds with typing indicator as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)